### PR TITLE
ci: (fix) Check out repo with a PAT.

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,7 +2,7 @@
   on:
     pull_request:
       paths:
-        - "csv/glossary.csv"
+        - "csv/**"
         - "json/**"
   
   jobs:
@@ -12,6 +12,8 @@
       steps:
         - name: Checkout repository
           uses: actions/checkout@v3
+          with:
+            token: ${{ secrets.SVC_ACCT_PAT }}
         - name: Install Python
           uses: actions/setup-python@v1
           with:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,9 +1,6 @@
 ---
   on:
     pull_request:
-      paths:
-        - "csv/**"
-        - "json/**"
   
   jobs:
     run-checks:


### PR DESCRIPTION
This (hopefully) fixes two issues:

- When the GitHub action that auto-commits files back to the PR is run and commits a new file to the PR, status checks don't re-trigger. This causes the PR to get stuck in an indefinite pending state
  - This is behavior with GitHub specifically and not with the action, but a workaround was found to use a PAT (Personal Access Token) to check the repository out instead of using the default action secret.
  - Reference: https://github.com/stefanzweifel/git-auto-commit-action/issues/163
- When updating `merge.xlsx`, the status check never runs as path filtering is enabled. As the status check is mandatory to pass, we're just going to run on all files in this repository. This repo is small enough and the checks run fast enough that this isn't a big deal.